### PR TITLE
Revamp UI layout and add placeholders

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,10 +1,10 @@
 :root {
-  --bg: #000;
+  --bg: #0d0d0d;
   --card-bg: #1e1e1e;
   --border: #333;
-  --accent: #00e5ff;
-  --fg: #eaeaea;
-  --shadow: 0 0 12px rgba(0, 229, 255, 0.35);
+  --accent: #ff4081;
+  --fg: #f5f5f5;
+  --shadow: 0 0 14px rgba(255, 64, 129, 0.35);
   --max-width: 1200px;
 }
 
@@ -12,7 +12,7 @@
 * { box-sizing: border-box; margin: 0; padding: 0; }
 
 body {
-  background: var(--bg);
+  background: linear-gradient(135deg, #1e1e1e 0%, #0d0d0d 80%);
   color: var(--fg);
   font-family: 'Roboto', sans-serif;
   min-height: 100vh;
@@ -23,22 +23,39 @@ body {
   position: fixed;
   top: 0; inset-inline: 0;
   height: 70px;
-  background: var(--card-bg);
+  background: rgba(0,0,0,0.7);
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
   align-items: center;
   padding-inline: 1.5rem;
   box-shadow: var(--shadow);
   z-index: 20;
 }
 
-.logo   { font-size: 1.4rem; font-weight: 700; }
-.tagline{ font-weight: 300; opacity: .8; }
+.logo   { font-size: 1.6rem; font-weight: 700; }
+.tagline{ font-weight: 300; opacity: .85; }
+
+/* HERO SECTION */
+.hero {
+  margin-top: 70px;
+  text-align: center;
+  padding: 4rem 1rem 3rem;
+  background: linear-gradient(135deg, #222 0%, #111 80%);
+}
+
+.hero h1 {
+  font-size: 2.5rem;
+  margin-bottom: .5rem;
+}
+
+.hero .tagline {
+  font-size: 1.1rem;
+}
 
 /* GRID CONTAINER */
 .grid {
   max-width: var(--max-width);
-  margin: 100px auto 2rem;        /* 70px header + extra spacing */
+  margin: 40px auto 2rem;
   padding-inline: 1rem;
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
@@ -51,7 +68,7 @@ body {
   aspect-ratio: 1 / 1;            /* perfect square */
   background: var(--card-bg);
   border: 2px solid var(--border);
-  border-radius: 8px;
+  border-radius: 10px;
   text-decoration: none;
   color: var(--fg);
   display: flex;
@@ -59,6 +76,19 @@ body {
   justify-content: center;
   align-items: center;
   transition: transform .15s, box-shadow .15s, border-color .15s;
+  overflow: hidden;
+}
+.card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, transparent, var(--accent));
+  opacity: 0;
+  transition: opacity .25s;
+}
+.card:hover::before,
+.card:focus-visible::before {
+  opacity: 0.2;
 }
 .card:hover,
 .card:focus-visible {

--- a/games/day2/index.html
+++ b/games/day2/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Game Day 2</title>
+  <meta charset="UTF-8">
+</head>
+<body style="background:black;color:white;text-align:center;">
+  <h2>Game Day 2</h2>
+  <p>Game coming soon!</p>
+</body>
+</html>

--- a/games/day3/index.html
+++ b/games/day3/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Game Day 3</title>
+  <meta charset="UTF-8">
+</head>
+<body style="background:black;color:white;text-align:center;">
+  <h2>Game Day 3</h2>
+  <p>Game coming soon!</p>
+</body>
+</html>

--- a/games/day4/index.html
+++ b/games/day4/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Game Day 4</title>
+  <meta charset="UTF-8">
+</head>
+<body style="background:black;color:white;text-align:center;">
+  <h2>Game Day 4</h2>
+  <p>Game coming soon!</p>
+</body>
+</html>

--- a/games/day5/index.html
+++ b/games/day5/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Game Day 5</title>
+  <meta charset="UTF-8">
+</head>
+<body style="background:black;color:white;text-align:center;">
+  <h2>Game Day 5</h2>
+  <p>Game coming soon!</p>
+</body>
+</html>

--- a/index
+++ b/index
@@ -7,10 +7,13 @@
   <link rel="stylesheet" href="/css/style.css">
 </head>
 <body>
-  <header>
-    <h1>🎮 AI Game Drop</h1>
-    <p>1 AI-generated game every day</p>
+  <header class="site-header">
+    <div class="logo">🎮 AI Game Drop</div>
   </header>
+  <section class="hero">
+    <h1>AI Game Drop</h1>
+    <p class="tagline">New AI-generated mini games every day</p>
+  </section>
 
   <div class="layout">
     <aside class="ad-left">[AD SPACE]</aside>
@@ -22,8 +25,8 @@
     <aside class="ad-right">[AD SPACE]</aside>
   </div>
 
-  <footer>
-    <p><a href="#">View all games</a></p>
+  <footer class="site-footer">
+    <a class="archive-link" href="#">View all games</a>
   </footer>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -19,10 +19,15 @@
   <!-- Header -->
   <header class="site-header">
     <div class="logo">🤖 AI Game Drop</div>
-    <div class="tagline">1 AI-generated game every day</div>
   </header>
 
-  <!-- SQUARE-CARD GRID -->
+  <!-- Hero Banner -->
+  <section class="hero">
+    <h1>AI Game Drop</h1>
+    <p class="tagline">New AI-generated mini games every day</p>
+  </section>
+
+  <!-- CARD GRID -->
   <main class="grid">
     <!-- Duplicate or remove cards as you add games -->
     <a class="card" href="games/day1/index.html">


### PR DESCRIPTION
## Summary
- refresh the landing page with a hero banner and updated card grid
- redesign site header and card styles for a modern look
- update alternate `index` page to match new layout
- add placeholder HTML files for days 2–5 so links work

## Testing
- `python tests/test_game_links.py`

------
https://chatgpt.com/codex/tasks/task_e_6840837bd59883249967ad5c65061c4d